### PR TITLE
 Update PulverizerDisplay.java, fix REI

### DIFF
--- a/src/main/java/abused_master/refinedmachinery/rei/plugin/PulverizerDisplay.java
+++ b/src/main/java/abused_master/refinedmachinery/rei/plugin/PulverizerDisplay.java
@@ -5,6 +5,7 @@ import abused_master.refinedmachinery.rei.RefinedMachineryPlugin;
 import me.shedaniel.rei.api.RecipeDisplay;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Identifier;
+import net.minecraft.recipe.Recipe;
 
 import java.util.Collections;
 import java.util.List;
@@ -21,7 +22,7 @@ public class PulverizerDisplay implements RecipeDisplay {
     }
 
     @Override
-    public Optional<PulverizerRecipes.PulverizerRecipe> getRecipe() {
+    public Optional<Recipe<?>> getRecipe() {
         return Optional.empty();
     }
 

--- a/src/main/java/abused_master/refinedmachinery/rei/plugin/PulverizerDisplay.java
+++ b/src/main/java/abused_master/refinedmachinery/rei/plugin/PulverizerDisplay.java
@@ -22,7 +22,7 @@ public class PulverizerDisplay implements RecipeDisplay {
 
     @Override
     public Optional<PulverizerRecipes.PulverizerRecipe> getRecipe() {
-        return Optional.ofNullable(recipe);
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
Fix #40 
Fix #42
Fix #47 

REI expects a Recipe: https://github.com/shedaniel/RoughlyEnoughItems/blob/5e9a5691c42b535eb9bb410fe366edfbae93192d/src/main/java/me/shedaniel/rei/api/RecipeDisplay.java#L18-L21, even in the older version: https://github.com/shedaniel/RoughlyEnoughItems/blob/6531e42054402b06f60f05a20ffbd25c3a47fc2d/src/main/java/me/shedaniel/rei/api/RecipeDisplay.java#L13